### PR TITLE
avoid including the tests dir in the coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = */tests/*


### PR DESCRIPTION
If pytest-conv is used this config file avoid including the `tests` directory in the coverage report.

new file:  `.coveragerc`